### PR TITLE
Customise the README, overwrite it in the VocPrez checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# VocPrez-theme-generic
-This is a copy of the default theme that comes with VocPrez. This repo can be used to wind back the application of any other theme.
+# British Geological Survey VocPrez
 
+This is the British Geological Survey instance of [VocPrez](https://github.com/RDFLib/VocPrez/), a read-only web delivery system for Simple Knowledge Organization System (SKOS)-formulated RDF vocabularies.

--- a/apply.sh
+++ b/apply.sh
@@ -3,3 +3,4 @@
 # replace styles
 cp -r ./VocPrez-theme-BGS/style ./VocPrez/vocprez/view/
 cp -r ./VocPrez-theme-BGS/templates ./VocPrez/vocprez/view/
+cp ./VocPrez-theme-BGS/README.md ./VocPrez/README.md


### PR DESCRIPTION
This copies the project README into the checked out version of https://github.com/RDFLib/VocPrez/ when we build our custom container for it. The "About" page on the VocPrez instance depends on having a `README.md` in the project root, and this was missing. 

I've done a separate one-line PR to VocPrez itself 