### PR TITLE
remove the _external=True from SPARQL endpoint links

### DIFF
--- a/templates/sparql.html
+++ b/templates/sparql.html
@@ -1,0 +1,147 @@
+{% extends "page.html" %}
+{%
+    set extra_styling = '
+        .yasgui .autocompleteWrapper {
+          display: none !important;
+        }
+
+        pre {
+            background-color: #eee;
+            padding:5px;
+        }
+    '
+%}
+{% block content %}
+    <h1>SPARQL</h1>
+    <p>
+        This page allows you to lodge <a href="https://en.wikipedia.org/wiki/SPARQL">SPARQL</a> queries against the
+        <a href="https://en.wikipedia.org/wiki/Triplestore">triplestore</a> (graph database) that stores all of this
+        systems' vocabularies'.
+    </p>
+    <p>Use the interactive Query UI below to lodge queries interactively or send queries directly to the system using the instructions below that.</p>
+    <div style="display: grid;">
+      <div style="grid-row:1; grid-column:1/3;">
+        <h2>Interactive UI</h2>
+        <p>Enter SPARQL queries in the text box below to lodge them interactively:</p>
+        <div id="yasgui" style="margin-bottom: 25px;"></div>
+      </div>
+      <div style="grid-row:2; grid-column:1; padding-right:10px;">
+        <h3>Example Queries</h3>
+        <h4>Concept Count</h4>
+        <p>
+          Here is an example query you can copy 'n paste into the Query UI text area above to test with. It counts the number of
+          vocabulary <em>Concepts</em> in the all vocabularies in this system and will return an integer:
+        </p>
+        <p><pre>
+PREFIX skos: &lt;http://www.w3.org/2004/02/skos/core#&gt;
+
+SELECT (COUNT(?c) AS ?count)
+WHERE {
+    ?c a skos:Concept .
+}
+        </pre></p>
+        <h4>Concepts</h4>
+        <p>
+          Here is another example. It returns the URI and prefLabel(s) of 5 random Concepts on this system:
+        </p>
+        <p><pre>
+PREFIX skos: &lt;http://www.w3.org/2004/02/skos/core#&gt;
+
+SELECT ?c ?pl
+WHERE {
+    ?c a skos:Concept ;
+       skos:prefLabel ?pl .
+}
+LIMIT 5
+        </pre></p>
+        <h4>Direct Querying</h4>
+        <p>
+          This query returns a sorted list of ConceptSchemes' (vocabularies) URIs and their titles (prefLabels):
+        </p>
+        <p><pre>
+PREFIX skos: &lt;http://www.w3.org/2004/02/skos/core#&gt;
+
+SELECT ?c ?pl
+WHERE {
+    ?c a skos:ConceptScheme ;
+       skos:prefLabel ?pl .
+}
+ORDER BY ?pl
+        </pre></p>
+      </div>
+      <div style="grid-row:2; grid-column:2;">
+        <h3>Direct Queries</h3>
+        <p>
+          If you would like to lodge queries directly against this SPARQL endpoint without using the Query UI
+          above, first create the query, URL-encode it, and lodge it like this:
+        </p>
+        <p><pre>
+{{ url_for('sparql') }}?query={YOUR_QUERY_URL_ENCODED}
+        </pre></p>
+        <p>You can use the query encoder below to URL-encode your query.</p>
+        <h4>Machine-readable responses</h4>
+        <p>If you lodge your query as above with a web browser, the system will place it in the interactive UI text area (above) and you will see the result below that.</p>
+        <p>To obtain a machine-readable response to your query, you must supply an HTTP Accept header for the type of response you would like, in accordance with the <a href="https://www.w3.org/TR/sparql11-protocol/">SPARQL Protocol standard</a>.</p>
+        <p>For example, to get a SPARQL JSON format response for <code>{YOUR_QUERY_URL_ENCODED}</code>, use the <a href="https://curl.haxx.se/">curl</a> program like this:</p>
+        <p><pre>
+curl {{ url_for('sparql') }}?query={YOUR_QUERY_URL_ENCODED}<br />-H 'Accept: application/sparql-results+json'
+        </pre></p>
+        <p><strong>SPARQL response Accept Headers</strong></p>
+        <p>The following Media Types are to be used for machine-readable responses:</p>
+        <ul>
+          <li>SPARQL response formats:
+            <ul>
+              <li><code>application/sparql-results+json</code></li>
+              <li><code>text/csv</code></li>
+              <li><code>text/tab-separated-values</code></li>
+            </ul>
+          </li>
+          <li>RDF response formats:
+            <ul>
+              <li><code>text/turtle</code></li>
+              <li><code>application/rdf+xml</code></li>
+              <li><code>application/ld+json</code></li>
+              <li><code>text/n3</code></li>
+              <li><code>application/n-triples</code></li>
+            </ul>
+        </ul>
+        <p>If you omit one of the above headers, your query will be placed into this page and the result displayed interactively.</p>
+        <p>If the header you've included doesn't match the format of the SPARQL response type, you will receive that response type's default format, e.g. <code>text/turtle</code> for <code>CONSTRUCT</code> queries, <code>application/sparql-results+json</code> for <code>SELECT</code> queries.</p>
+        <p><strong>GET &amp; POST queries</strong></p>
+        <p>You can lodge both <code>GET</code> and <code>POST</code> queries against this system, as per the <a href="https://www.w3.org/TR/sparql11-protocol/">SPARQL Protocol standard</a>.</p>
+        <h4>Query Encoder</h4>
+        <p>
+          Enter your SPARQL query into this text box and click "URL Encode" to URL encode it. That will
+          generate a single encoded string with spaces replaced by "%20" and other character replacements
+          which you can then use in place of <code>{YOUR_QUERY_URL_ENCODED}</code> above.
+        </p>
+        <p>
+            You might like to test out your query first using the Query UI above too.
+        </p>
+        <textarea id="encoding_query" style="width:100%; min-height:100px;"></textarea>
+        <button id="url_encode">URL Encode</button> <button id="url_decode">URL Decode</button>
+      </div>
+    </div>
+    <p>&nbsp;</p>
+    <link href='https://unpkg.com/@triply/yasgui/build/yasgui.min.css' rel='stylesheet' type='text/css'/>
+    <script src='https://unpkg.com/@triply/yasgui/build/yasgui.min.js'></script>
+    <script type="text/javascript">
+        /*
+        var yasgui = YASGUI(document.getElementById("yasgui"), {
+            yasqe:{sparql:{endpoint:'{{ url_for('sparql') }}'}} // default endpoint
+        });
+        */
+        const yasgui = new Yasgui(document.getElementById("yasgui"), {
+          requestConfig: { endpoint: "{{ url_for('sparql') }}" },
+          copyEndpointOnNewTab: false
+        });
+
+        document.getElementById("url_encode").addEventListener("click", function() {
+          document.getElementById("encoding_query").value = encodeURIComponent(document.getElementById("encoding_query").value);
+        });
+
+        document.getElementById("url_decode").addEventListener("click", function() {
+          document.getElementById("encoding_query").value = decodeURIComponent(document.getElementById("encoding_query").value);
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
We shouldn't really need a custom SPARQL endpoint template (harder for us to track updates), but this won't display a container hostname rather than a provided one. Ideally supply an optional hostname in VocPrez' config, don't see clear option...

